### PR TITLE
Fix ESC selection when not all ESCs are available

### DIFF
--- a/components/SerialDevice.vue
+++ b/components/SerialDevice.vue
@@ -225,7 +225,7 @@
             </div>
             <div class="w-full text-center flex justify-center gap-2">
               <div
-                v-for="n of escStore.selectedEscInfo.length"
+                v-for="n of escStore.selectedEscInfo.map(e => e.index + 1)"
                 :key="n"
                 class="transition-all w-8 h-8 rounded-full text-center border border-gray-500 bg-gray-800 p-1 cursor-pointer"
                 :class="{
@@ -284,7 +284,7 @@
               </div>
               <div class="w-full text-center flex justify-center gap-2">
                 <div
-                  v-for="n of escStore.selectedEscInfo.length"
+                  v-for="n of escStore.selectedEscInfo.map(e => e.index + 1)"
                   :key="n"
                   class="transition-all w-8 h-8 rounded-full text-center border border-gray-500 bg-gray-800 p-1 cursor-pointer"
                   :class="{
@@ -323,7 +323,7 @@
               </div>
               <div class="w-full text-center flex justify-center gap-2">
                 <div
-                  v-for="n of escStore.selectedEscInfo.length"
+                  v-for="n of escStore.selectedEscInfo.map(e => e.index + 1)"
                   :key="n"
                   class="transition-all w-8 h-8 rounded-full text-center border border-gray-500 bg-gray-800 p-1 cursor-pointer"
                   :class="{
@@ -363,7 +363,7 @@
               </div>
               <div class="w-full text-center flex justify-center gap-2">
                 <div
-                  v-for="n of escStore.selectedEscInfo.length"
+                  v-for="n of escStore.selectedEscInfo.map(e => e.index + 1)"
                   :key="n"
                   class="transition-all w-8 h-8 rounded-full text-center border border-gray-500 bg-gray-800 p-1 cursor-pointer"
                   :class="{

--- a/src/communication/four_way.ts
+++ b/src/communication/four_way.ts
@@ -390,7 +390,14 @@ export class FourWay {
                 readbackSettings = (await this.readAddress(mcu.getEepromOffset(), Mcu.LAYOUT_SIZE));
 
                 if (readbackSettings) {
+                    // The bootloader writes it revision number so we can't compare it
+                    // as it could be different.
+                    readbackSettings.params[2] = newSettingsArray[2]
+
                     if (!compare(newSettingsArray, readbackSettings.params)) {
+                        console.error('SettingsVerificationError');
+                        console.error(newSettingsArray);
+                        console.error(readbackSettings.params);
                         throw new Error('SettingsVerificationError(newSettingsArray, readbackSettings)');
                     }
 

--- a/stores/esc.ts
+++ b/stores/esc.ts
@@ -6,7 +6,12 @@ export const useEscStore = defineStore('esc', () => {
 
     const escData = ref<EscData[]>([]);
 
-    const selectedEscInfo = computed(() => escData.value.filter(e => !e.isError && e.data?.isSelected).map(e => e.data) ?? []);
+    const selectedEscInfo = computed(() =>
+        escData.value
+            .map((e, index) => ({ ...e, index }))
+            .filter(e => !e.isError && e.data?.isSelected)
+            .map(e => ({ ...e.data, index: e.index })) ?? []
+    );
     const firstValidEscData = computed(() => escData.value?.find(d => !d.isError && d.data));
 
     const settingsDirty = ref(false);


### PR DESCRIPTION
This should fix the issue described on discord where flashing wouldn't work when the ESC you have less than the expected number of ESCs connected and an offset exists between the `selectedEscInfo` and `escData`.

https://discord.com/channels/1029170737342316605/1218531833961123950/1315472000000462980

The solution here should improve on the one I posted to discord as it keeps the ESC number consistent with the numbers shown next to the buttons in the top right.

I tested this only by writing the default config and my testing setup is somewhat limited so extra testing wouldn't hurt. @tridge would you be able to check if it solves your issue?

At the same time, when writing the default config with the bootloader in master (v13) the bootloader seems to overwrite its revision number and so the compare was always failing. I fixed that by ignoring the bootloader revision byte in the compare.