### PR TITLE
Add support for 128KB flash MCUs

### DIFF
--- a/src/communication/four_way.ts
+++ b/src/communication/four_way.ts
@@ -147,7 +147,8 @@ export class FourWay {
         const eepromOffset = mcu.getEepromOffset();
 
         try {
-            const fileNameRead = await this.readAddress(eepromOffset - 32, 32);
+            const fileNameOffset = (eepromOffset - 32) >> mcu.getEepromAddressShift();
+            const fileNameRead = await this.readAddress(fileNameOffset, 32);
             const fileName = new TextDecoder().decode(fileNameRead!.params.slice(0, fileNameRead?.params.indexOf(0x0)));
 
             if (/[A-Z0-9_]+/.test(fileName)) {
@@ -162,7 +163,8 @@ export class FourWay {
 
             mcu.getInfo().layoutSize = Mcu!.LAYOUT_SIZE;
 
-            const settingsArray = (await this.readAddress(eepromOffset, mcu.getInfo().layoutSize))!.params;
+            const settingsArrayOffset = eepromOffset >> mcu.getEepromAddressShift();
+            const settingsArray = (await this.readAddress(settingsArrayOffset, mcu.getInfo().layoutSize))!.params;
             mcu.getInfo().settings = bufferToSettings(settingsArray);
             mcu.getInfo().settingsBuffer = settingsArray;
 

--- a/src/mcu.ts
+++ b/src/mcu.ts
@@ -8,6 +8,7 @@ export interface McuVariant {
     flash_offset: string;
     firmware_start: string;
     eeprom_offset: string;
+    eeprom_address_shift: number;
 }
 
 export interface McuInfo {
@@ -54,7 +55,8 @@ class Mcu {
                 flash_size: 65536,
                 flash_offset: '0x08000000',
                 firmware_start: '0x1000',
-                eeprom_offset: '0x7c00'
+                eeprom_offset: '0x7c00',
+                eeprom_address_shift: 0,
             },
             3506: {
                 name: 'ARM64K',
@@ -63,7 +65,18 @@ class Mcu {
                 flash_size: 65536,
                 flash_offset: '0x08000000',
                 firmware_start: '0x1000',
-                eeprom_offset: '0xF800'
+                eeprom_offset: '0xF800',
+                eeprom_address_shift: 0,
+            },
+            '2B06': {
+                name: 'STM32G071 128KB',
+                signature: '0x2b06',
+                page_size: 2048,
+                flash_size: 131072,
+                flash_offset: '0x08000000',
+                firmware_start: '0x1000',
+                eeprom_offset: '0x1F800',
+                eeprom_address_shift: 2,
             }
         };
 
@@ -135,6 +148,17 @@ class Mcu {
      */
     getEepromOffset () {
         return parseInt(this.mcu.eeprom_offset, 16);
+    }
+
+    /**
+     * Get shit in number of bits of the EEprom offset for the four way communication.
+     * This is needed because the address is coded on 2 bytes but for large flash
+     * MCUs the address goes beyond the range (e.g. 0x1F800)
+     *
+     * @returns {number}
+     */
+    getEepromAddressShift() {
+        return this.mcu.eeprom_address_shift;
     }
 
     /**


### PR DESCRIPTION
When porting AM32 to the STM32G0B1 I noticed that the configurator actually doesn't work with MCUs that have 128KB of flash for multiple reasons.

The first reason is because there is no target with that signature. The second reason is because the eeprom memorry addressing for `0x1F800` didn't work. It failed when trying to get the ESC filename because it was subtracting 32 bytes from the already shifted address instead of the real address.

I had it working previously, but I made some changes and I haven't tested in the latest form.