### PR TITLE
fix: improve topbar implementation to prevent overflow

### DIFF
--- a/components/Log.vue
+++ b/components/Log.vue
@@ -3,10 +3,8 @@
     <div class="flex flex-col text-sm h-full w-full">
       <LogView />
     </div>
-    <div class="absolute top-0 right-0 w-[60px]">
-      <div class="fixed p-1">
-        <UIcon name="i-ph-arrows-out" class="drop-shadow-sm cursor-pointer transition-all hover:text-red-500 active:text-red-950" @click="logModal = true" />
-      </div>
+    <div class="absolute top-2 right-2">
+      <UIcon name="i-ph-arrows-out" class="drop-shadow-sm cursor-pointer transition-all hover:text-red-500 active:text-red-950" @click="logModal = true" />
     </div>
     <UModal
       v-model="logModal"

--- a/components/SerialDevice.vue
+++ b/components/SerialDevice.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="min-w-[320px]">
-    <div class="p-4 grid grid-cols-1 gap-2">
+    <div class="grid grid-cols-1 gap-2">
       <div class="flex flex-column gap-2">
         <USelectMenu v-model="serialStore.selectedDevice" class="flex-grow" :disabled="serialStore.hasConnection" :options="serialStore.pairedDevicesOptions" placeholder="Select device" />
         <USelectMenu
@@ -396,7 +396,6 @@ import commandsQueue from '~/src/communication/commands.queue';
 import { DIRECT_COMMANDS, Direct } from '~/src/communication/direct';
 import { FOUR_WAY_COMMANDS, FourWay } from '~/src/communication/four_way';
 import Msp, { MSP_COMMANDS } from '~/src/communication/msp';
-import serial from '~/src/communication/serial';
 import Serial from '~/src/communication/serial';
 import db from '~/src/db';
 import Flash from '~/src/flash';

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,22 +1,17 @@
 <template>
   <div>
     <div>
-      <div class="grid grid-cols-12 text-white ">
-        <div class="col-span-2 flex justify-center items-center">
-          <div class="bg-red-800 max-h-[180px] rounded-2xl">
-            <img :src="logo" class="max-h-[180px] w-auto">
-          </div>
-        </div>
-        <div class="col-span-8 h-[200px] max-h-[200px]">
-          <div class="h-full font-bold text-3xl text-red-800 flex flex-col">
-            <div v-if="logStore.entries.length === 0">
-              AlkaMotors
-            </div>
+      <div class="max-w-[1400px] p-4 grid grid-rows-[120px_1fr] lg:grid-rows-[200px] grid-cols-[120px_1fr] lg:grid-cols-[180px_1fr_320px] gap-4 mx-auto items-center text-white">
+        <img :src="logo" class="max-h-[180px] col-start-1 col-span-1 aspect-auto rounded-2xl bg-red-800">
 
-            <Log v-else class="h-full overflow-auto" />
-          </div>
+        <div class="h-full col-start-2 col-span-1 flex flex-col text-red-800 font-bold text-3xl">
+          <span v-if="logStore.entries.length === 0">
+            AlkaMotors
+          </span>
+          <Log v-else class="h-full overflow-auto" />
         </div>
-        <div v-if="serialStore.hasSerial" class="col-span-2">
+
+        <div v-if="serialStore.hasSerial" class="h-full col-start-2 lg:col-start-3 ">
           <SerialDevice />
         </div>
       </div>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,6 +1,6 @@
-import type { Config } from 'tailwindcss';
-import { iconsPlugin, getIconCollections } from '@egoist/tailwindcss-icons';
+import { getIconCollections, iconsPlugin } from '@egoist/tailwindcss-icons';
 import typography from '@tailwindcss/typography';
+import type { Config } from 'tailwindcss';
 
 export default {
     content: {
@@ -18,6 +18,9 @@ export default {
     ],
     theme: {
         extend: {
+            screens: {
+                lg: '800px'
+            }
         },
         fontFamily: {
             sans: ["'Nunito Sans'"]


### PR DESCRIPTION
Currently the implementation of the top bar creates a overflow scroll on laptop screens. This makes the configurator cumbersome to use and makes the user experience worse.

I made a couple little fixes to the top bar to eliminate tis issue:


**Changes made:**
- allow shrinking of elements
- move serial device controls to second line for small screens

Code Cleanup:
- removed unnecessary containers
- simplified paddings
- simplified alignment of fullscreen log button

Screenshots:
<img width="1285" alt="Screenshot 2025-03-24 at 09 17 45" src="https://github.com/user-attachments/assets/7c9651d5-8442-4070-bdd3-c8b6bcad52f4" />

<img width="1049" alt="Screenshot 2025-03-24 at 09 18 00" src="https://github.com/user-attachments/assets/ba333dbc-99bc-4f8d-bf81-c97874db7dc3" />

<img width="1016" alt="Screenshot 2025-03-24 at 09 18 08" src="https://github.com/user-attachments/assets/31343eef-c358-47fa-8b4a-6cb9daa7853a" />



